### PR TITLE
bug: Fix to get rid of the console error message: "sap.app/type entry in manifest is not 'card' - "

### DIFF
--- a/webapp/model/cardsManifest.json
+++ b/webapp/model/cardsManifest.json
@@ -1,5 +1,8 @@
 {
   "ListDefaultHeader": {
+        "sap.app": {
+      "type": "card"
+    },
     "sap.card": {
       "type": "List",
       "header": {
@@ -68,6 +71,9 @@
     }
   },
   "ListNumericHeader": {
+        "sap.app": {
+      "type": "card"
+    },
     "sap.card": {
       "type": "List",
       "header": {
@@ -97,6 +103,9 @@
     }
   },
   "AnalyticalCard": {
+        "sap.app": {
+      "type": "card"
+    },
     "sap.card": {
       "type": "Analytical",
       "header": {


### PR DESCRIPTION
Typical superfluous mandatory UI5 setting, it has no added value but required by the UI5 developers…